### PR TITLE
Add the ability to always remove the file from the server

### DIFF
--- a/includes/admin/controllers/uploads.php
+++ b/includes/admin/controllers/uploads.php
@@ -53,14 +53,10 @@ class NF_FU_Admin_Controllers_Uploads {
 				continue;
 			}
 
-			foreach ( $field['value'] as $upload_id => $url ) {
-				$upload = $this->get( $upload_id );
-
-				$file_path = $upload->file_path;
-
-				if ( file_exists( $file_path ) ) {
+			foreach ( $field['files'] as $file ) {
+				if ( isset( $file['data']['file_path'] ) && file_exists( $file['data']['file_path'] ) ) {
 					// Delete local file
-					unlink( $file_path );
+					unlink( $file['data']['file_path'] );
 				}
 			}
 		}

--- a/includes/admin/controllers/uploads.php
+++ b/includes/admin/controllers/uploads.php
@@ -42,11 +42,14 @@ class NF_FU_Admin_Controllers_Uploads {
 				continue;
 			}
 
-			if ( ! isset( $field['save_to_server'] ) ) {
+			// The ability to always remove the file from the server, overriding the field setting
+			$force_remove = apply_filters( 'ninja_forms_uploads_remove_files_from_server', false, $field );
+
+			if ( ! $force_remove && ! isset( $field['save_to_server'] ) ) {
 				continue;
 			}
 
-			if ( "1" == $field['save_to_server'] ) {
+			if ( ! $force_remove && "1" == $field['save_to_server'] ) {
 				continue;
 			}
 


### PR DESCRIPTION
Overriding the field setting, via a filter

Resolves https://github.com/wpninjas/ninja-forms-uploads/issues/144

You would need to add this to a mu-plugin, functionality plugin or theme's functions.php -

`add_filter( 'ninja_forms_uploads_remove_files_from_server', '__return_true' );`