### PR TITLE
Make sure the table gets created if the version setting doesn't exist.

### DIFF
--- a/includes/database/migrations/uploads.php
+++ b/includes/database/migrations/uploads.php
@@ -38,7 +38,7 @@ PRIMARY KEY (id)
 			return;
 		}
 		
-		$current_version = Ninja_Forms()->get_setting( $this->version_key, NF_File_Uploads()->plugin_version );
+		$current_version = Ninja_Forms()->get_setting( $this->version_key, '0' );
 		$version        = $this->version;
 
 		if ( version_compare( $current_version, $version, '!=' ) ) {


### PR DESCRIPTION
Resolves https://github.com/wpninjas/ninja-forms-uploads/issues/271