### PR TITLE
Add single localized upload nonce.

### DIFF
--- a/assets/js/front-end/controllers/fieldFile.js
+++ b/assets/js/front-end/controllers/fieldFile.js
@@ -114,7 +114,7 @@
 		initFileUpload: function( view ) {
 			var fieldID = view.model.id;
 			var formID = view.model.get( 'formID' );
-			var nonce = view.model.get( 'uploadNonce' );
+            var nonce = nf_upload.nonce;
 			var $file = $( view.el ).find( '.nf-element' );
 			var $files_uploaded = $( view.el ).find( '.files_uploaded' );
 			this.$progress_bars[ fieldID ] = $( view.el ).find( '.nf-fu-progress-bar' );

--- a/includes/ajax/controllers/uploads.php
+++ b/includes/ajax/controllers/uploads.php
@@ -33,7 +33,7 @@ class NF_FU_AJAX_Controllers_Uploads extends NF_Abstracts_Controller {
 			$this->_respond();
 		}
 
-		$result = check_ajax_referer( 'nf-file-upload-' . $field_id, 'nonce', false );
+		$result = check_ajax_referer( 'nf-file-upload', 'nonce', false );
 		if ( false === $result ) {
 			$this->_errors[] = __( 'Nonce error', 'ninja-forms-uploads' );
 			$this->_respond();

--- a/includes/display/render.php
+++ b/includes/display/render.php
@@ -74,6 +74,7 @@ class NF_FU_Display_Render {
 				'select_files'         => isset( $settings['select_files_text'] ) ? $settings['select_files_text'] : __( 'Select Files', 'ninja-forms-uploads' ),
 				'delete_file'          => __( 'Delete', 'ninja-forms-uploads' ),
 			) ),
+            'nonce' => wp_create_nonce( 'nf-file-upload' )
 		) );
 
 		wp_enqueue_style( 'nf-fu-jquery-fileupload', $url . 'assets/css/file-upload.css', array(), $ver );


### PR DESCRIPTION
As an interim step to resolving the expired nonce issue in Save Progress, I suggest that we move to a single upload nonce which is localized with the form display as opposed to storing the nonce in the field data.

Closes #270.