### PR TITLE
Move upload nonces to form model.

### DIFF
--- a/assets/js/front-end/controllers/fieldFile.js
+++ b/assets/js/front-end/controllers/fieldFile.js
@@ -44,6 +44,12 @@
 		},
 
 		initFile: function( model ) {
+
+			// On (initial) form load, move any upload nonces to the parent form model.
+            this.listenTo( nfRadio.channel( 'form-' + model.get( 'formID' ) ), 'loaded', function( formModel ){
+            	console.log( 'STORE Nonce: ' + model.get( 'uploadNonce' ) );
+				formModel.set( 'upload-nonce-' + model.get( 'id' ), model.get( 'uploadNonce' ) );
+			} );
 			model.set( 'uploadMulti', 1 != model.get( 'upload_multi_count' ) ) ;
 		},
 
@@ -114,7 +120,9 @@
 		initFileUpload: function( view ) {
 			var fieldID = view.model.id;
 			var formID = view.model.get( 'formID' );
-			var nonce = view.model.get( 'uploadNonce' );
+			var form = Backbone.Radio.channel( 'app' ).request( 'get:form', formID );
+			var nonce = form.get( 'upload-nonce-' + fieldID );
+			console.log( 'Fetched Nonce: ' + nonce );
 			var $file = $( view.el ).find( '.nf-element' );
 			var $files_uploaded = $( view.el ).find( '.files_uploaded' );
 			this.$progress_bars[ fieldID ] = $( view.el ).find( '.nf-fu-progress-bar' );

--- a/includes/fields/upload.php
+++ b/includes/fields/upload.php
@@ -56,6 +56,11 @@ class NF_FU_Fields_Upload extends NF_Abstracts_Field {
 			return $data;
 		}
 
+		// If we are saving, as opposed to a regular submission, then bail.
+        if( isset( $data[ 'extra' ][ 'saveProgress' ] ) ){
+            return $data;
+        }
+
 		$submission_data = array();
 
 		// Get common data


### PR DESCRIPTION
The Save Progress add-on replaces the `FieldCollection`, which overrides the fresh upload nonces.

This moves the upload nonces to the form model which avoids the issue of expired nonces being stored by Save Progress.

Also, this adds a check for saves (vs submits) so that files are not pre-maturely moved from the temp folder.

Fixes #270 .
Replaces #293 .
Closes wpninjas/ninja-forms-save-progress#66 .