### PR TITLE
Use file extension whitelist as the input file accept attribute.

### DIFF
--- a/includes/fields/upload.php
+++ b/includes/fields/upload.php
@@ -253,6 +253,19 @@ class NF_FU_Fields_Upload extends NF_Abstracts_Field {
 		$settings['max_file_size'] = $max_file_size;
 		$settings['uploadNonce'] = wp_create_nonce( 'nf-file-upload-' . $settings['id'] );
 		$settings['select_files_text'] = ! empty ( $settings['select_files_text'] ) ? $settings['select_files_text'] : apply_filters( 'ninja_forms_upload_select_files_text', __( 'Select Files', 'ninja-forms-uploads' ) );
+		if ( ! empty( $settings['upload_types'] ) ) {
+			$types = array_map( 'trim', explode( ',', $settings['upload_types'] ) );
+
+			if ( in_array( 'jpg', $types ) && ! in_array( 'jpeg', $types ) ) {
+				$types[] = 'jpeg';
+			}
+
+			array_walk( $types, function ( &$value ) {
+				$value = '.' . ltrim( $value, '.' );
+			} );
+
+			$settings['upload_types'] = implode( ',', $types );
+		}
 
 		return $settings;
 	}

--- a/includes/templates/fields-file-upload.html
+++ b/includes/templates/fields-file-upload.html
@@ -2,7 +2,7 @@
 	<button class="btn btn-success nf-fu-fileinput-button" type="button">
         <span>{{{ data.select_files_text }}}</span>
     </button>
-	<input class="nf-element" style="display: block; visibility: hidden; width: 0; height: 0;" type="file" <# data.uploadMulti ? print( 'name="files[]" multiple' ) : print ( 'name="files"' ) #>>
+	<input class="nf-element" style="display: block; visibility: hidden; width: 0; height: 0;" type="file" <# data.uploadMulti ? print( 'name="files[]" multiple' ) : print ( 'name="files"' ) #> <# data.upload_types ? print( 'accept=" ' + data.upload_types + '"' ) : '' #>>
 	<input type="hidden" class="nf-upload-nonce" value="{{{ data.uploadNonce }}}">
 	<div class="nf-fu-progress">
 		<div class="nf-fu-progress-bar nf-fu-progress-bar-success animate"></div>


### PR DESCRIPTION
Resolves https://github.com/wpninjas/ninja-forms-uploads/issues/324