### PR TITLE
Optionally overwrite existing files

### DIFF
--- a/includes/config/field-settings.php
+++ b/includes/config/field-settings.php
@@ -13,7 +13,16 @@ return apply_filters( 'ninja_forms_uploads_field_settings', array(
 		'group' => 'primary',
 		'width' => 'one-half',
 		'help'  => __( 'Save the file to the server.', 'ninja-forms-uploads' ),
-	),
+  ),
+  'overwrite_existing' => array(
+    'name' => 'overwrite_existing',
+    'type' => 'toggle',
+    'value' => '',
+    'label' => __('Overwrite existing', 'ninja-forms-uploads'),
+    'group' => 'primary',
+    'width' => 'one-half',
+    'help' => __( 'Overwrite the existing file, or otherwise append an index.', 'ninja-forms-uploads' ),
+  ),
 	'upload_rename'      => array(
 		'name'  => 'upload_rename',
 		'type'  => 'textbox',

--- a/includes/fields/upload.php
+++ b/includes/fields/upload.php
@@ -114,7 +114,7 @@ class NF_FU_Fields_Upload extends NF_Abstracts_Field {
 			$file_name   = sanitize_file_name( basename( $target_file ) );
 			$target_file = $target_path . '/' . $file_name;
 
-			if ( file_exists( $target_file ) ) {
+			if ( file_exists( $target_file ) && empty( $field['overwrite_existing'] ) ) {
 				// Make sure we use a filename that is unique
 				$original_target_file = $target_file;
 


### PR DESCRIPTION
File overwrite is sometimes desired, so this change adds a toggleable option for each file upload field on whether a file should be overwritten (off by default).

Fixes #344 