### PR TITLE
Resolves #301: Nonce Errors

### DIFF
--- a/includes/ajax/controllers/uploads.php
+++ b/includes/ajax/controllers/uploads.php
@@ -33,7 +33,9 @@ class NF_FU_AJAX_Controllers_Uploads extends NF_Abstracts_Controller {
 			$this->_respond();
 		}
 
-		$result = check_ajax_referer( 'nf-file-upload-' . $field_id, 'nonce', false );
+		list( $field_id_no_instance ) = explode( '_', $field_id );
+
+		$result = check_ajax_referer( 'nf-file-upload-' . $field_id_no_instance, 'nonce', false );
 		if ( false === $result ) {
 			$this->_errors[] = __( 'Nonce error', 'ninja-forms-uploads' );
 			$this->_respond();


### PR DESCRIPTION
**Steps to reproduce:**
- Add a ninja form with a file upload field.
- Add that form to an Article.
- Attempt to use the file upload.

**Image of the bug:**
![image](https://user-images.githubusercontent.com/9660445/106811023-bd4d5e80-663b-11eb-87fd-efc8fb695c38.png)

**Expected Output:**
- The nonce should pass.
![image](https://user-images.githubusercontent.com/9660445/106811368-351b8900-663c-11eb-9951-74cf7482f137.png)

**Root Cause Analysis:**

![image](https://user-images.githubusercontent.com/9660445/106811475-5f6d4680-663c-11eb-8e9f-479d309e0b61.png)

Ninja Forms introduced this code "render_instance_count". This changes field_id to append an underscore and an instance count. (e.g. if it was `11` now it may be `11_1` or `11_3`).

![image](https://user-images.githubusercontent.com/9660445/106811720-bf63ed00-663c-11eb-989b-0ffbde50bfab.png)

When this occurs, the upload form fails to validate the nonce because it is using the field ID without the instance count.

I verified this by outputting the raw nonce string instead of passing it thru wp_create_nonce:

![image](https://user-images.githubusercontent.com/9660445/106811881-f5a16c80-663c-11eb-950e-8d3dfea68002.png)

**Suggested Solution:**

Since instance count is determined at the time of render, and is a private static variable not exposed by the Ninja Forms renderer, AND I could not think of an intuitive way to share it.. the best solution I came up with was to just strip the instance string off. If there's a way to account for the above and also include the instance string it may be a better fix.